### PR TITLE
Fix for placeholder alignment issue 

### DIFF
--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
@@ -173,7 +173,7 @@
     // Use RGB values found via Photoshop for placeholder color #c7c7cd.
     if (_shouldDrawPlaceholder) {
         UIColor *placeholderGray = [UIColor colorWithRed:199/255.f green:199/255.f blue:205/255.f alpha:1.f];
-        [_cachedPlaceholder drawInRect:CGRectMake(5.f,ceil(tempSizeOfField/2) - floor(tempFontSize/2) - 2.0f, self.frame.size.width, self.frame.size.height)
+        [_cachedPlaceholder drawInRect:CGRectMake(5.f,ceil(tempSizeOfField/2) - floor(tempFontSize/2), self.frame.size.width, self.frame.size.height)
                         withAttributes:@{NSFontAttributeName : self.font,
                                          NSForegroundColorAttributeName : placeholderGray}];
     }


### PR DESCRIPTION
Now the placeholder text aligns in the middle of the
RPFloatingPlaceholderTextField just like as in the the default
UITextField irrespective of the height of the box

Before:
![before](https://f.cloud.github.com/assets/1040583/1435775/ed721676-4147-11e3-9f9d-302c6b8eceb3.png)

After : 
![after](https://f.cloud.github.com/assets/1040583/1435779/005103d8-4148-11e3-9406-4ce04aa8890b.png)
