### PR TITLE
check if floating label color were set before awakeFromNib

### DIFF
--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
@@ -162,8 +162,8 @@
         // iOS 6
         defaultActiveColor = [UIColor blueColor];
     }
-    self.floatingLabelActiveTextColor = defaultActiveColor;
-    self.floatingLabelInactiveTextColor = [UIColor colorWithWhite:0.7f alpha:1.f];
+    self.floatingLabelActiveTextColor = self.floatingLabelActiveTextColor ?: defaultActiveColor;
+    self.floatingLabelInactiveTextColor = self.floatingLabelInactiveTextColor ?: [UIColor colorWithWhite:0.7f alpha:1.f];
     
     self.floatingLabel.textColor = self.floatingLabelActiveTextColor;
 }

--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextView.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextView.m
@@ -181,8 +181,8 @@
         // iOS 6
         defaultActiveColor = [UIColor blueColor];
     }
-    self.floatingLabelActiveTextColor = defaultActiveColor;
-    self.floatingLabelInactiveTextColor = [UIColor colorWithWhite:0.7f alpha:1.f];
+    self.floatingLabelActiveTextColor = self.floatingLabelActiveTextColor ?: defaultActiveColor;
+    self.floatingLabelInactiveTextColor = self.floatingLabelInactiveTextColor ?: [UIColor colorWithWhite:0.7f alpha:1.f];
     
     self.floatingLabel.textColor = self.floatingLabelActiveTextColor;
 }


### PR DESCRIPTION
If you setup a `RPFloatingPlaceholders` instance in Xib/Storyboard and setup the floating label colors when overriding the setter in the viewController nothing happens because `awakeFromNib` es called after.