### PR TITLE
Show floating label without animation when text is set programmatically

### DIFF
--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
@@ -338,6 +338,12 @@
 
 - (void)textFieldTextDidChange:(NSNotification *)notification
 {
+	//Text was set programmatically, so show the floating label but don't animate it
+	if (!notification && self.hasText) {
+		[self showFloatingLabelWithAnimation:NO];
+		return;
+	}
+	
     BOOL previousShouldDrawPlaceholderValue = self.shouldDrawPlaceholder;
     self.shouldDrawPlaceholder = !self.hasText;
     


### PR DESCRIPTION
Thanks for a great library! This tweak is to prevent the unwanted floating label animation when loading a textfield programmatically (as when loading a form with pre-filled values). This works fine for me, but please let me know if you recommend a better solution.