### PR TITLE
Draw placeholder properly in RTL

### DIFF
--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
@@ -202,6 +202,7 @@
     // Use RGB values found via Photoshop for placeholder color #c7c7cd.
     if (self.shouldDrawPlaceholder) {
         UIColor *placeholderGray = self.defaultPlaceholderColor ?: [UIColor colorWithRed:199/255.f green:199/255.f blue:205/255.f alpha:1.f];
+        //Inset the placeholder by the same 5px on both sides so that it works in RTL too
         CGRect placeholderFrame = CGRectMake(5.f, floorf((self.frame.size.height - self.font.lineHeight) / 2.f), self.frame.size.width - 10, self.frame.size.height);
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         [paragraphStyle setAlignment: self.textAlignment];

--- a/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
+++ b/RPFloatingPlaceholders/RPFloatingPlaceholderTextField.m
@@ -202,7 +202,7 @@
     // Use RGB values found via Photoshop for placeholder color #c7c7cd.
     if (self.shouldDrawPlaceholder) {
         UIColor *placeholderGray = self.defaultPlaceholderColor ?: [UIColor colorWithRed:199/255.f green:199/255.f blue:205/255.f alpha:1.f];
-        CGRect placeholderFrame = CGRectMake(5.f, floorf((self.frame.size.height - self.font.lineHeight) / 2.f), self.frame.size.width, self.frame.size.height);
+        CGRect placeholderFrame = CGRectMake(5.f, floorf((self.frame.size.height - self.font.lineHeight) / 2.f), self.frame.size.width - 10, self.frame.size.height);
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
         [paragraphStyle setAlignment: self.textAlignment];
         


### PR DESCRIPTION
In a right-to-left language, the placeholder is drawn in the wrong position because it's frame is slightly too big, this fixes it.